### PR TITLE
Avoid adding to secondary blocks created on the page, e.g. with register_sidebar

### DIFF
--- a/mooberry-book-manager.php
+++ b/mooberry-book-manager.php
@@ -434,6 +434,11 @@
 	function mbdb_content($content) {
 		global $wp_query;
 
+		// Don't add to sidebar or other widgets, only to the central content block of the page.
+		if ( !in_the_loop() || !is_main_query() ) {
+			return $content;
+		}
+
 		// make sure it's the post type 'book'
 		if (get_post_type() == 'mbdb_book' && is_main_query() && !is_admin()) {
 			$content .= mbdb_book_content($content);


### PR DESCRIPTION
We had a problem that we used `register_sidebar` twice to create a couple more blocks on our page.

Each block was firing the `the_content` filter.  And so we ended up with three book-grids on our page, instead of just the one we wanted in the content.

This patch fixed it.

In fact `!in_the_loop()` was enough for us, but I heard the `is_main_query()` check recommended here: http://wordpress.stackexchange.com/questions/67716/how-to-determine-if-a-filter-is-called-in-a-sidebar-widget-context

Some more tips here: https://pippinsplugins.com/playing-nice-with-the-content-filter/
